### PR TITLE
Adiciona mais testes de unidade para a biblioteca Comum (lote 2)

### DIFF
--- a/Bibliotecas/EtiquetasBibliotecas.Comum/Arrays/ArrayStringPossuiAlgumElementoVazioOuComEspaco.cs
+++ b/Bibliotecas/EtiquetasBibliotecas.Comum/Arrays/ArrayStringPossuiAlgumElementoVazioOuComEspaco.cs
@@ -16,10 +16,11 @@ namespace Etiquetas.Bibliotecas.Comum.Arrays
         /// </returns>
         public static bool Execute(string[] array)
         {
-            var vazio = array == null;
-            vazio = vazio || array.Length == 0;
-            vazio = vazio || array.Any(x => EhStringNuloVazioComEspacosBranco.Execute(x));
-            return vazio;
+            if (array == null || array.Length == 0)
+            {
+                return false;
+            }
+            return array.Any(x => EhStringNuloVazioComEspacosBranco.Execute(x));
         }
     }
 }

--- a/Testes/Etiquetas.Bibliotecas.Comum.Tests/Arrays/ArrayStringPossuiAlgumElementoVazioOuComEspacoTests.cs
+++ b/Testes/Etiquetas.Bibliotecas.Comum.Tests/Arrays/ArrayStringPossuiAlgumElementoVazioOuComEspacoTests.cs
@@ -1,0 +1,86 @@
+using Xunit;
+using Etiquetas.Bibliotecas.Comum.Arrays;
+
+namespace Etiquetas.Bibliotecas.Comum.Tests.Arrays
+{
+    public class ArrayStringPossuiAlgumElementoVazioOuComEspacoTests
+    {
+        [Fact]
+        public void Execute_ComElementoVazio_RetornaTrue()
+        {
+            // Arrange
+            var array = new[] { "a", "", "c" };
+
+            // Act
+            var result = ArrayStringPossuiAlgumElementoVazioOuComEspaco.Execute(array);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void Execute_ComElementoNulo_RetornaTrue()
+        {
+            // Arrange
+            var array = new[] { "a", null, "c" };
+
+            // Act
+            var result = ArrayStringPossuiAlgumElementoVazioOuComEspaco.Execute(array);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void Execute_ComElementoDeEspaco_RetornaTrue()
+        {
+            // Arrange
+            var array = new[] { "a", " ", "c" };
+
+            // Act
+            var result = ArrayStringPossuiAlgumElementoVazioOuComEspaco.Execute(array);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void Execute_SemElementosVazios_RetornaFalse()
+        {
+            // Arrange
+            var array = new[] { "a", "b", "c" };
+
+            // Act
+            var result = ArrayStringPossuiAlgumElementoVazioOuComEspaco.Execute(array);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void Execute_ComArrayNulo_RetornaFalse()
+        {
+            // Arrange
+            string[] array = null;
+
+            // Act
+            var result = ArrayStringPossuiAlgumElementoVazioOuComEspaco.Execute(array);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void Execute_ComArrayVazio_RetornaFalse()
+        {
+            // Arrange
+            var array = new string[] { };
+
+            // Act
+            var result = ArrayStringPossuiAlgumElementoVazioOuComEspaco.Execute(array);
+
+            // Assert
+            Assert.False(result);
+        }
+    }
+}

--- a/Testes/Etiquetas.Bibliotecas.Comum.Tests/Arrays/CharArrayEmStringArrayTests.cs
+++ b/Testes/Etiquetas.Bibliotecas.Comum.Tests/Arrays/CharArrayEmStringArrayTests.cs
@@ -1,0 +1,64 @@
+using Xunit;
+using Etiquetas.Bibliotecas.Comum.Arrays;
+
+namespace Etiquetas.Bibliotecas.Comum.Tests.Arrays
+{
+    public class CharArrayEmStringArrayTests
+    {
+        [Fact]
+        public void Execute_ComArrayDeChars_RetornaArrayDeStrings()
+        {
+            // Arrange
+            var arrayChar = new[] { 'a', 'b', 'c' };
+            var expected = new[] { "a", "b", "c" };
+
+            // Act
+            var result = CharArrayEmStringArray.Execute(arrayChar);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComArrayNulo_RetornaArrayVazio()
+        {
+            // Arrange
+            char[] arrayChar = null;
+            var expected = new string[] { };
+
+            // Act
+            var result = CharArrayEmStringArray.Execute(arrayChar);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComArrayVazio_RetornaArrayVazio()
+        {
+            // Arrange
+            var arrayChar = new char[] { };
+            var expected = new string[] { };
+
+            // Act
+            var result = CharArrayEmStringArray.Execute(arrayChar);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComCaracteresEspeciais_ConverteCorretamente()
+        {
+            // Arrange
+            var arrayChar = new[] { ' ', '\t', '\0' };
+            var expected = new[] { " ", "\t", "\0" };
+
+            // Act
+            var result = CharArrayEmStringArray.Execute(arrayChar);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/Testes/Etiquetas.Bibliotecas.Comum.Tests/Arrays/CompareStringArrayTests.cs
+++ b/Testes/Etiquetas.Bibliotecas.Comum.Tests/Arrays/CompareStringArrayTests.cs
@@ -1,0 +1,92 @@
+using Xunit;
+using Etiquetas.Bibliotecas.Comum.Arrays;
+
+namespace Etiquetas.Bibliotecas.Comum.Tests.Arrays
+{
+    public class CompareStringArrayTests
+    {
+        [Fact]
+        public void Execute_ComArraysDeStringsIguais_RetornaTrue()
+        {
+            // Arrange
+            var array1 = new[] { "a", "b", "c" };
+            var array2 = new[] { "a", "b", "c" };
+
+            // Act
+            var result = CompareStringArray.Execute(array1, array2);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void Execute_ComArraysDeStringsDiferentes_RetornaFalse()
+        {
+            // Arrange
+            var array1 = new[] { "a", "b", "c" };
+            var array2 = new[] { "c", "b", "a" };
+
+            // Act
+            var result = CompareStringArray.Execute(array1, array2);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void Execute_ComUmArrayNulo_RetornaFalse()
+        {
+            // Arrange
+            var array1 = new[] { "a", "b", "c" };
+            object array2 = null;
+
+            // Act
+            var result = CompareStringArray.Execute(array1, array2);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void Execute_ComAmbosNulos_RetornaFalse()
+        {
+            // Arrange
+            object array1 = null;
+            object array2 = null;
+
+            // Act
+            var result = CompareStringArray.Execute(array1, array2);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void Execute_ComTiposDeArrayDiferentes_RetornaFalse()
+        {
+            // Arrange
+            var array1 = new[] { "a", "b", "c" };
+            var array2 = new[] { 1, 2, 3 };
+
+            // Act
+            var result = CompareStringArray.Execute(array1, array2);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void Execute_ComArraysDeOutroTipo_RetornaFalse()
+        {
+            // Arrange
+            var array1 = new[] { 1, 2, 3 };
+            var array2 = new[] { 1, 2, 3 };
+
+            // Act
+            var result = CompareStringArray.Execute(array1, array2);
+
+            // Assert
+            Assert.False(result);
+        }
+    }
+}


### PR DESCRIPTION
Este commit continua o trabalho de adicionar cobertura de testes para a biblioteca `Etiquetas.Bibliotecas.Comum`.

- Adiciona testes de unidade para as classes `ArrayStringPossuiAlgumElementoVazioOuComEspaco`, `CharArrayEmStringArray` e `CompareStringArray`.
- Corrige um bug de referência nula em `ArrayStringPossuiAlgumElementoVazioOuComEspaco`.