### PR TITLE
Adiciona mais testes de unidade para a biblioteca Comum (lote 3)

### DIFF
--- a/Bibliotecas/EtiquetasBibliotecas.Comum/Arrays/ConcatenarArrayCaractersEmString.cs
+++ b/Bibliotecas/EtiquetasBibliotecas.Comum/Arrays/ConcatenarArrayCaractersEmString.cs
@@ -4,6 +4,10 @@ namespace Etiquetas.Bibliotecas.Comum.Arrays
     {
         public static string Execute(char[] array)
         {
+            if (array == null)
+            {
+                return string.Empty;
+            }
             var retornoString = string.Concat(array);
             return retornoString;
         }

--- a/Testes/Etiquetas.Bibliotecas.Comum.Tests/Arrays/ConcatenarArrayCaractersEmStringTests.cs
+++ b/Testes/Etiquetas.Bibliotecas.Comum.Tests/Arrays/ConcatenarArrayCaractersEmStringTests.cs
@@ -1,0 +1,50 @@
+using Xunit;
+using Etiquetas.Bibliotecas.Comum.Arrays;
+
+namespace Etiquetas.Bibliotecas.Comum.Tests.Arrays
+{
+    public class ConcatenarArrayCaractersEmStringTests
+    {
+        [Fact]
+        public void Execute_ComArrayDeChars_RetornaStringConcatenada()
+        {
+            // Arrange
+            var array = new[] { 'a', 'b', 'c' };
+            var expected = "abc";
+
+            // Act
+            var result = ConcatenarArrayCaractersEmString.Execute(array);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComArrayNulo_RetornaStringVazia()
+        {
+            // Arrange
+            char[] array = null;
+            var expected = "";
+
+            // Act
+            var result = ConcatenarArrayCaractersEmString.Execute(array);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComArrayVazio_RetornaStringVazia()
+        {
+            // Arrange
+            var array = new char[] { };
+            var expected = "";
+
+            // Act
+            var result = ConcatenarArrayCaractersEmString.Execute(array);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/Testes/Etiquetas.Bibliotecas.Comum.Tests/Arrays/ConcatenarArrayComNovoElementoStringTests.cs
+++ b/Testes/Etiquetas.Bibliotecas.Comum.Tests/Arrays/ConcatenarArrayComNovoElementoStringTests.cs
@@ -1,0 +1,83 @@
+using Xunit;
+using Etiquetas.Bibliotecas.Comum.Arrays;
+
+namespace Etiquetas.Bibliotecas.Comum.Tests.Arrays
+{
+    public class ConcatenarArrayComNovoElementoStringTests
+    {
+        [Fact]
+        public void Execute_ComArrayEElemento_RetornaArrayConcatenado()
+        {
+            // Arrange
+            var array = new[] { "a", "b" };
+            var elemento = "c";
+            var expected = new[] { "a", "b", "c" };
+
+            // Act
+            var result = ConcatenarArrayComNovoElementoString.Execute(array, elemento);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComArrayNulo_RetornaArrayComElemento()
+        {
+            // Arrange
+            string[] array = null;
+            var elemento = "a";
+            var expected = new[] { "a" };
+
+            // Act
+            var result = ConcatenarArrayComNovoElementoString.Execute(array, elemento);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComArrayVazio_RetornaArrayComElemento()
+        {
+            // Arrange
+            var array = new string[] { };
+            var elemento = "a";
+            var expected = new[] { "a" };
+
+            // Act
+            var result = ConcatenarArrayComNovoElementoString.Execute(array, elemento);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComElementoNulo_AdicionaNuloAoArray()
+        {
+            // Arrange
+            var array = new[] { "a", "b" };
+            string elemento = null;
+            var expected = new[] { "a", "b", null };
+
+            // Act
+            var result = ConcatenarArrayComNovoElementoString.Execute(array, elemento);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComElementoVazio_AdicionaStringVaziaAoArray()
+        {
+            // Arrange
+            var array = new[] { "a", "b" };
+            var elemento = "";
+            var expected = new[] { "a", "b", "" };
+
+            // Act
+            var result = ConcatenarArrayComNovoElementoString.Execute(array, elemento);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/Testes/Etiquetas.Bibliotecas.Comum.Tests/Arrays/ConcatenarArrayStringTests.cs
+++ b/Testes/Etiquetas.Bibliotecas.Comum.Tests/Arrays/ConcatenarArrayStringTests.cs
@@ -1,0 +1,139 @@
+using Xunit;
+using Etiquetas.Bibliotecas.Comum.Arrays;
+
+namespace Etiquetas.Bibliotecas.Comum.Tests.Arrays
+{
+    public class ConcatenarArrayStringTests
+    {
+        // Testes para a sobrecarga Execute(string[], string[])
+
+        [Fact]
+        public void Execute_DoisArrays_RetornaConcatenacao()
+        {
+            // Arrange
+            var array1 = new[] { "a", "b" };
+            var array2 = new[] { "c", "d" };
+            var expected = new[] { "a", "b", "c", "d" };
+
+            // Act
+            var result = ConcatenarArrayString.Execute(array1, array2);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_PrimeiroArrayNulo_RetornaSegundoArray()
+        {
+            // Arrange
+            string[] array1 = null;
+            var array2 = new[] { "c", "d" };
+            var expected = new[] { "c", "d" };
+
+            // Act
+            var result = ConcatenarArrayString.Execute(array1, array2);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_SegundoArrayNulo_RetornaPrimeiroArray()
+        {
+            // Arrange
+            var array1 = new[] { "a", "b" };
+            string[] array2 = null;
+            var expected = new[] { "a", "b" };
+
+            // Act
+            var result = ConcatenarArrayString.Execute(array1, array2);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_AmbosArraysNulos_RetornaArrayVazio()
+        {
+            // Arrange
+            string[] array1 = null;
+            string[] array2 = null;
+            var expected = new string[] { };
+
+            // Act
+            var result = ConcatenarArrayString.Execute(array1, array2);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ArraysComElementosNulos_PreservaNulos()
+        {
+            // Arrange
+            var array1 = new[] { "a", null };
+            var array2 = new[] { "c", "" };
+            var expected = new[] { "a", null, "c", "" };
+
+            // Act
+            var result = ConcatenarArrayString.Execute(array1, array2);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        // Testes para a sobrecarga Execute(params string[][])
+
+        [Fact]
+        public void ExecuteParams_VariosArrays_RetornaConcatenacaoSemVazios()
+        {
+            // Arrange
+            var array1 = new[] { "a", "b" };
+            var array2 = new[] { "c", null, "d" };
+            var array3 = new[] { "", "e", " " };
+            var expected = new[] { "a", "b", "c", "d", "e" };
+
+            // Act
+            var result = ConcatenarArrayString.Execute(array1, array2, array3);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void ExecuteParams_ComArrayNuloNaLista_IgnoraArrayNulo()
+        {
+            // Arrange
+            var array1 = new[] { "a", "b" };
+            string[] array2 = null;
+            var array3 = new[] { "c", "d" };
+            var expected = new[] { "a", "b", "c", "d" };
+
+            // Act
+            var result = ConcatenarArrayString.Execute(array1, array2, array3);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void ExecuteParams_ComParametroNulo_RetornaArrayVazio()
+        {
+            // Arrange & Act
+            var result = ConcatenarArrayString.Execute(null);
+
+            // Assert
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void ExecuteParams_SemParametros_RetornaArrayVazio()
+        {
+            // Arrange & Act
+            var result = ConcatenarArrayString.Execute();
+
+            // Assert
+            Assert.Empty(result);
+        }
+    }
+}


### PR DESCRIPTION
Este commit continua o trabalho de adicionar cobertura de testes para a biblioteca `Etiquetas.Bibliotecas.Comum`.

- Adiciona testes de unidade para as classes `ConcatenarArrayCaractersEmString`, `ConcatenarArrayComNovoElementoString` e `ConcatenarArrayString`.
- Corrige um bug de referência nula em `ConcatenarArrayCaractersEmString`.