### PR TITLE
Adiciona mais testes de unidade para a biblioteca Comum (lote 4)

### DIFF
--- a/Bibliotecas/EtiquetasBibliotecas.Comum/Caracteres/AlteraCaractere.cs
+++ b/Bibliotecas/EtiquetasBibliotecas.Comum/Caracteres/AlteraCaractere.cs
@@ -19,6 +19,10 @@ namespace Etiquetas.Bibliotecas.Comum.Caracteres
         /// </returns>
         public static string Execute(this string texto, char caractere, char novoCaractere)
         {
+            if (texto == null)
+            {
+                return null;
+            }
             return texto.Replace(caractere, novoCaractere);
         }
     }

--- a/Bibliotecas/EtiquetasBibliotecas.Comum/Caracteres/AlteraTexto.cs
+++ b/Bibliotecas/EtiquetasBibliotecas.Comum/Caracteres/AlteraTexto.cs
@@ -20,6 +20,14 @@ namespace Etiquetas.Bibliotecas.Comum.Caracteres
         /// </returns>
         public static string Execute(this string texto, string parteTexto, string novoConteudo)
         {
+            if (texto == null)
+            {
+                return null;
+            }
+            if (parteTexto == null)
+            {
+                return texto;
+            }
             return texto.Replace(parteTexto, novoConteudo);
         }
     }

--- a/Bibliotecas/EtiquetasBibliotecas.Comum/Caracteres/ArrayBytesEmString.cs
+++ b/Bibliotecas/EtiquetasBibliotecas.Comum/Caracteres/ArrayBytesEmString.cs
@@ -10,17 +10,20 @@ namespace Etiquetas.Bibliotecas.Comum.Caracteres
     {
         public static string Execute(byte[] bytes, int bytesLidos, Encoding encoding)
         {
+            if (bytes == null) return null;
             return encoding.GetString(bytes, 0, bytesLidos);
         }
 
         public static string Execute(byte[] bytes, Encoding encoding)
         {
+            if (bytes == null) return null;
             return encoding.GetString(bytes, 0, bytes.Length);
         }
 
-        public static string Execute(byte[] bytes, int posicaoInicial, int posicaoFinal, Encoding encoding)
+        public static string Execute(byte[] bytes, int posicaoInicial, int count, Encoding encoding)
         {
-            return encoding.GetString(bytes, posicaoInicial, posicaoFinal);
+            if (bytes == null) return null;
+            return encoding.GetString(bytes, posicaoInicial, count);
         }
     }
 }

--- a/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/AlteraCaractereTests.cs
+++ b/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/AlteraCaractereTests.cs
@@ -1,0 +1,71 @@
+using Xunit;
+using Etiquetas.Bibliotecas.Comum.Caracteres;
+
+namespace Etiquetas.Bibliotecas.Comum.Tests.Caracteres
+{
+    public class AlteraCaractereTests
+    {
+        [Fact]
+        public void Execute_QuandoCaractereExiste_SubstituiCorretamente()
+        {
+            // Arrange
+            var texto = "banana";
+            var caractere = 'a';
+            var novoCaractere = 'o';
+            var expected = "bonono";
+
+            // Act
+            var result = AlteraCaractere.Execute(texto, caractere, novoCaractere);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_QuandoCaractereNaoExiste_NaoAlteraTexto()
+        {
+            // Arrange
+            var texto = "banana";
+            var caractere = 'x';
+            var novoCaractere = 'o';
+            var expected = "banana";
+
+            // Act
+            var result = AlteraCaractere.Execute(texto, caractere, novoCaractere);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_QuandoTextoEhNulo_RetornaNulo()
+        {
+            // Arrange
+            string texto = null;
+            var caractere = 'a';
+            var novoCaractere = 'o';
+
+            // Act
+            var result = AlteraCaractere.Execute(texto, caractere, novoCaractere);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Execute_QuandoTextoEstaVazio_RetornaTextoVazio()
+        {
+            // Arrange
+            var texto = "";
+            var caractere = 'a';
+            var novoCaractere = 'o';
+            var expected = "";
+
+            // Act
+            var result = AlteraCaractere.Execute(texto, caractere, novoCaractere);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/AlteraTextoTests.cs
+++ b/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/AlteraTextoTests.cs
@@ -1,0 +1,103 @@
+using Xunit;
+using Etiquetas.Bibliotecas.Comum.Caracteres;
+
+namespace Etiquetas.Bibliotecas.Comum.Tests.Caracteres
+{
+    public class AlteraTextoTests
+    {
+        [Fact]
+        public void Execute_QuandoParteTextoExiste_SubstituiCorretamente()
+        {
+            // Arrange
+            var texto = "isto é um teste";
+            var parteTexto = "um teste";
+            var novoConteudo = "um exemplo";
+            var expected = "isto é um exemplo";
+
+            // Act
+            var result = AlteraTexto.Execute(texto, parteTexto, novoConteudo);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_QuandoParteTextoNaoExiste_NaoAlteraTexto()
+        {
+            // Arrange
+            var texto = "isto é um teste";
+            var parteTexto = "nao existe";
+            var novoConteudo = "um exemplo";
+            var expected = "isto é um teste";
+
+            // Act
+            var result = AlteraTexto.Execute(texto, parteTexto, novoConteudo);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_QuandoTextoEhNulo_RetornaNulo()
+        {
+            // Arrange
+            string texto = null;
+            var parteTexto = "teste";
+            var novoConteudo = "exemplo";
+
+            // Act
+            var result = AlteraTexto.Execute(texto, parteTexto, novoConteudo);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Execute_QuandoParteTextoEhNulo_RetornaTextoOriginal()
+        {
+            // Arrange
+            var texto = "isto é um teste";
+            string parteTexto = null;
+            var novoConteudo = "exemplo";
+            var expected = "isto é um teste";
+
+            // Act
+            var result = AlteraTexto.Execute(texto, parteTexto, novoConteudo);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_QuandoNovoConteudoEhNulo_SubstituiPorVazio()
+        {
+            // Arrange
+            var texto = "isto é um teste";
+            var parteTexto = " um teste";
+            string novoConteudo = null;
+            var expected = "isto é";
+
+            // Act
+            var result = AlteraTexto.Execute(texto, parteTexto, novoConteudo);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_QuandoTextoEstaVazio_RetornaTextoVazio()
+        {
+            // Arrange
+            var texto = "";
+            var parteTexto = "teste";
+            var novoConteudo = "exemplo";
+            var expected = "";
+
+            // Act
+            var result = AlteraTexto.Execute(texto, parteTexto, novoConteudo);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/ArrayBytesEmStringTests.cs
+++ b/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/ArrayBytesEmStringTests.cs
@@ -1,0 +1,92 @@
+using Xunit;
+using Etiquetas.Bibliotecas.Comum.Caracteres;
+using System.Text;
+using System;
+
+namespace Etiquetas.Bibliotecas.Comum.Tests.Caracteres
+{
+    public class ArrayBytesEmStringTests
+    {
+        // Testes para Execute(byte[], int, Encoding)
+        [Fact]
+        public void ExecuteComBytesLidos_ComArrayValido_RetornaString()
+        {
+            // Arrange
+            var bytes = Encoding.UTF8.GetBytes("teste");
+            var expected = "tes";
+
+            // Act
+            var result = ArrayBytesEmString.Execute(bytes, 3, Encoding.UTF8);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void ExecuteComBytesLidos_ComArrayNulo_RetornaNulo()
+        {
+            // Arrange
+            byte[] bytes = null;
+
+            // Act
+            var result = ArrayBytesEmString.Execute(bytes, 0, Encoding.UTF8);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        // Testes para Execute(byte[], Encoding)
+        [Fact]
+        public void ExecuteCompleto_ComArrayValido_RetornaStringCompleta()
+        {
+            // Arrange
+            var bytes = Encoding.UTF8.GetBytes("teste");
+            var expected = "teste";
+
+            // Act
+            var result = ArrayBytesEmString.Execute(bytes, Encoding.UTF8);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void ExecuteCompleto_ComEncodingDiferente_RetornaStringDiferente()
+        {
+            // Arrange
+            var bytes = Encoding.ASCII.GetBytes("tésté");
+            var expected = "teste"; // ASCII não tem acentos
+
+            // Act
+            var result = ArrayBytesEmString.Execute(bytes, Encoding.UTF8);
+
+            // Assert
+            Assert.NotEqual(expected, result);
+        }
+
+        // Testes para Execute(byte[], int, int, Encoding)
+        [Fact]
+        public void ExecuteComRange_ComRangeValido_RetornaSubstring()
+        {
+            // Arrange
+            var bytes = Encoding.UTF8.GetBytes("teste");
+            var expected = "est";
+
+            // Act
+            var result = ArrayBytesEmString.Execute(bytes, 1, 3, Encoding.UTF8);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void ExecuteComRange_ComRangeInvalido_LancaExcecao()
+        {
+            // Arrange
+            var bytes = Encoding.UTF8.GetBytes("teste");
+
+            // Act & Assert
+            Assert.Throws<ArgumentOutOfRangeException>(() => ArrayBytesEmString.Execute(bytes, 1, 5, Encoding.UTF8));
+        }
+    }
+}


### PR DESCRIPTION
Este commit continua o trabalho de adicionar cobertura de testes para a biblioteca `Etiquetas.Bibliotecas.Comum`, focando no diretório `Caracteres`.

- Adiciona testes de unidade para as classes `AlteraCaractere`, `AlteraTexto` e `ArrayBytesEmString`.
- Corrige bugs de referência nula em todas as três classes para garantir um comportamento mais robusto.