### PR TITLE
Adiciona mais testes de unidade para a biblioteca Comum (lote 5)

### DIFF
--- a/Bibliotecas/EtiquetasBibliotecas.Comum/Caracteres/ConcatenarArrayCaracteresEmString.cs
+++ b/Bibliotecas/EtiquetasBibliotecas.Comum/Caracteres/ConcatenarArrayCaracteresEmString.cs
@@ -4,8 +4,11 @@ namespace Etiquetas.Bibliotecas.Comum.Caracteres
     {
         public static string Execute(char[] array)
         {
-            string retornoString = string.Concat(new string(array));
-            return retornoString;
+            if (array == null)
+            {
+                return string.Empty;
+            }
+            return new string(array);
         }
     }
 }

--- a/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/ConcatenarArrayCaracteresEmStringTests.cs
+++ b/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/ConcatenarArrayCaracteresEmStringTests.cs
@@ -1,0 +1,50 @@
+using Xunit;
+using Etiquetas.Bibliotecas.Comum.Caracteres;
+
+namespace Etiquetas.Bibliotecas.Comum.Tests.Caracteres
+{
+    public class ConcatenarArrayCaracteresEmStringTests
+    {
+        [Fact]
+        public void Execute_ComArrayDeChars_RetornaString()
+        {
+            // Arrange
+            var array = new[] { 't', 'e', 's', 't', 'e' };
+            var expected = "teste";
+
+            // Act
+            var result = ConcatenarArrayCaracteresEmString.Execute(array);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComArrayNulo_RetornaStringVazia()
+        {
+            // Arrange
+            char[] array = null;
+            var expected = "";
+
+            // Act
+            var result = ConcatenarArrayCaracteresEmString.Execute(array);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComArrayVazio_RetornaStringVazia()
+        {
+            // Arrange
+            var array = new char[] { };
+            var expected = "";
+
+            // Act
+            var result = ConcatenarArrayCaracteresEmString.Execute(array);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/ConcatenarCaractereTextoTests.cs
+++ b/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/ConcatenarCaractereTextoTests.cs
@@ -1,0 +1,68 @@
+using Xunit;
+using Etiquetas.Bibliotecas.Comum.Caracteres;
+
+namespace Etiquetas.Bibliotecas.Comum.Tests.Caracteres
+{
+    public class ConcatenarCaractereTextoTests
+    {
+        [Fact]
+        public void Execute_ComCharEString_RetornaConcatenacao()
+        {
+            // Arrange
+            var caractere = 'a';
+            var texto = "bc";
+            var expected = "abc";
+
+            // Act
+            var result = ConcatenarCaractereTexto.Execute(caractere, texto);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComStringNula_RetornaCharComoString()
+        {
+            // Arrange
+            var caractere = 'a';
+            string texto = null;
+            var expected = "a";
+
+            // Act
+            var result = ConcatenarCaractereTexto.Execute(caractere, texto);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComStringVazia_RetornaCharComoString()
+        {
+            // Arrange
+            var caractere = 'a';
+            var texto = "";
+            var expected = "a";
+
+            // Act
+            var result = ConcatenarCaractereTexto.Execute(caractere, texto);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComCharDeEspaco_ConcatenaCorretamente()
+        {
+            // Arrange
+            var caractere = ' ';
+            var texto = "abc";
+            var expected = " abc";
+
+            // Act
+            var result = ConcatenarCaractereTexto.Execute(caractere, texto);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/ConcatenarCaractersTests.cs
+++ b/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/ConcatenarCaractersTests.cs
@@ -1,0 +1,61 @@
+using Xunit;
+using Etiquetas.Bibliotecas.Comum.Caracteres;
+
+namespace Etiquetas.Bibliotecas.Comum.Tests.Caracteres
+{
+    public class ConcatenarCaractersTests
+    {
+        [Fact]
+        public void Execute_ComVariosCaracteres_RetornaStringConcatenada()
+        {
+            // Arrange
+            var expected = "abc";
+
+            // Act
+            var result = ConcatenarCaracters.Execute('a', 'b', 'c');
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_SemCaracteres_RetornaStringVazia()
+        {
+            // Arrange
+            var expected = "";
+
+            // Act
+            var result = ConcatenarCaracters.Execute();
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComUmCaractere_RetornaStringComUmCaractere()
+        {
+            // Arrange
+            var expected = "a";
+
+            // Act
+            var result = ConcatenarCaracters.Execute('a');
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComArrayNulo_RetornaStringVazia()
+        {
+            // Arrange
+            char[] caracteres = null;
+            var expected = "";
+
+            // Act
+            var result = ConcatenarCaracters.Execute(caracteres);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/ConcatenarTextoTests.cs
+++ b/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/ConcatenarTextoTests.cs
@@ -1,0 +1,87 @@
+using Xunit;
+using Etiquetas.Bibliotecas.Comum.Caracteres;
+
+namespace Etiquetas.Bibliotecas.Comum.Tests.Caracteres
+{
+    public class ConcatenarTextoTests
+    {
+        [Fact]
+        public void Execute_ComVariosTextos_RetornaStringConcatenada()
+        {
+            // Arrange
+            var expected = "abcdef";
+
+            // Act
+            var result = ConcatenarTexto.Execute("abc", "def");
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_SemTextos_RetornaStringVazia()
+        {
+            // Arrange
+            var expected = "";
+
+            // Act
+            var result = ConcatenarTexto.Execute();
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComUmTexto_RetornaOProprioTexto()
+        {
+            // Arrange
+            var expected = "abc";
+
+            // Act
+            var result = ConcatenarTexto.Execute("abc");
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComTextoNulo_TrataComoVazio()
+        {
+            // Arrange
+            var expected = "abcdef";
+
+            // Act
+            var result = ConcatenarTexto.Execute("abc", null, "def");
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComTextoVazio_ConcatenaNormalmente()
+        {
+            // Arrange
+            var expected = "abcdef";
+
+            // Act
+            var result = ConcatenarTexto.Execute("abc", "", "def");
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComArrayNulo_RetornaStringVazia()
+        {
+            // Arrange
+            string[] textos = null;
+            var expected = "";
+
+            // Act
+            var result = ConcatenarTexto.Execute(textos);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+    }
+}


### PR DESCRIPTION
Este commit continua o trabalho de adicionar cobertura de testes para a biblioteca `Etiquetas.Bibliotecas.Comum`, focando no diretório `Caracteres`.

- Adiciona testes de unidade para as classes `ConcatenarArrayCaracteresEmString`, `ConcatenarCaractereTexto`, `ConcatenarCaracters` e `ConcatenarTexto`.
- Corrige um bug de referência nula em `ConcatenarArrayCaracteresEmString`.