### PR TITLE
Adiciona mais testes de unidade para a biblioteca Comum (lote 6)

### DIFF
--- a/Bibliotecas/EtiquetasBibliotecas.Comum/Caracteres/ConcatenarTextoCaracterSeUltimoCaracterDiferente.cs
+++ b/Bibliotecas/EtiquetasBibliotecas.Comum/Caracteres/ConcatenarTextoCaracterSeUltimoCaracterDiferente.cs
@@ -4,15 +4,15 @@ namespace Etiquetas.Bibliotecas.Comum.Caracteres
     {
         public static string Execute(string texto, char caractere)
         {
-            if (EhStringNuloVazioComEspacosBranco.Execute(texto) && EhStringNuloVazioComEspacosBranco.Execute(caractere.ToString()))
+            if (string.IsNullOrEmpty(texto))
             {
-                return null;
+                return caractere.ToString();
             }
-            if ((ExtrairTextoDireita.Execute(texto, 1) ?? "") != ($"{caractere}" ?? ""))
+            if (texto[texto.Length - 1] != caractere)
             {
-                return $"{texto}{caractere}";
+                return texto + caractere;
             }
-            return $"{texto}";
+            return texto;
         }
 
     }

--- a/Bibliotecas/EtiquetasBibliotecas.Comum/Caracteres/ConcatenarVariosArraysStringEmString.cs
+++ b/Bibliotecas/EtiquetasBibliotecas.Comum/Caracteres/ConcatenarVariosArraysStringEmString.cs
@@ -14,7 +14,7 @@ namespace Etiquetas.Bibliotecas.Comum.Caracteres
                 return string.Empty;
 
             // Usando LINQ para mesclar todos os arrays e concatenar em uma única string
-            return string.Concat(arrays.SelectMany(array => array));
+            return string.Concat(arrays.Where(a => a != null).SelectMany(array => array));
         }
 
         public static string ExecuteStringBuilder(params string[][] arrays)

--- a/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/ConcatenarTextoCaracterSeUltimoCaracterDiferenteTests.cs
+++ b/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/ConcatenarTextoCaracterSeUltimoCaracterDiferenteTests.cs
@@ -1,0 +1,98 @@
+using Xunit;
+using Etiquetas.Bibliotecas.Comum.Caracteres;
+
+namespace Etiquetas.Bibliotecas.Comum.Tests.Caracteres
+{
+    public class ConcatenarTextoCaracterSeUltimoCaracterDiferenteTests
+    {
+        [Fact]
+        public void Execute_QuandoUltimoCharDiferente_Concatena()
+        {
+            // Arrange
+            var texto = "abc";
+            var caractere = 'd';
+            var expected = "abcd";
+
+            // Act
+            var result = ConcatenarTextoCaracterSeUltimoCaracterDiferente.Execute(texto, caractere);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_QuandoUltimoCharIgual_NaoConcatena()
+        {
+            // Arrange
+            var texto = "abc";
+            var caractere = 'c';
+            var expected = "abc";
+
+            // Act
+            var result = ConcatenarTextoCaracterSeUltimoCaracterDiferente.Execute(texto, caractere);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_QuandoTextoNulo_RetornaCharComoString()
+        {
+            // Arrange
+            string texto = null;
+            var caractere = 'a';
+            var expected = "a";
+
+            // Act
+            var result = ConcatenarTextoCaracterSeUltimoCaracterDiferente.Execute(texto, caractere);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_QuandoTextoVazio_RetornaCharComoString()
+        {
+            // Arrange
+            var texto = "";
+            var caractere = 'a';
+            var expected = "a";
+
+            // Act
+            var result = ConcatenarTextoCaracterSeUltimoCaracterDiferente.Execute(texto, caractere);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComCharDeEspaco_ConcatenaSeDiferente()
+        {
+            // Arrange
+            var texto = "abc";
+            var caractere = ' ';
+            var expected = "abc ";
+
+            // Act
+            var result = ConcatenarTextoCaracterSeUltimoCaracterDiferente.Execute(texto, caractere);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComCharDeEspaco_NaoConcatenaSeIgual()
+        {
+            // Arrange
+            var texto = "abc ";
+            var caractere = ' ';
+            var expected = "abc ";
+
+            // Act
+            var result = ConcatenarTextoCaracterSeUltimoCaracterDiferente.Execute(texto, caractere);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/ConcatenarTextoCaracterTests.cs
+++ b/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/ConcatenarTextoCaracterTests.cs
@@ -1,0 +1,68 @@
+using Xunit;
+using Etiquetas.Bibliotecas.Comum.Caracteres;
+
+namespace Etiquetas.Bibliotecas.Comum.Tests.Caracteres
+{
+    public class ConcatenarTextoCaracterTests
+    {
+        [Fact]
+        public void Execute_ComStringEChar_RetornaConcatenacao()
+        {
+            // Arrange
+            var texto = "ab";
+            var caractere = 'c';
+            var expected = "abc";
+
+            // Act
+            var result = ConcatenarTextoCaracter.Execute(texto, caractere);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComStringNula_RetornaCharComoString()
+        {
+            // Arrange
+            string texto = null;
+            var caractere = 'a';
+            var expected = "a";
+
+            // Act
+            var result = ConcatenarTextoCaracter.Execute(texto, caractere);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComStringVazia_RetornaCharComoString()
+        {
+            // Arrange
+            var texto = "";
+            var caractere = 'a';
+            var expected = "a";
+
+            // Act
+            var result = ConcatenarTextoCaracter.Execute(texto, caractere);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComCharDeEspaco_ConcatenaCorretamente()
+        {
+            // Arrange
+            var texto = "abc";
+            var caractere = ' ';
+            var expected = "abc ";
+
+            // Act
+            var result = ConcatenarTextoCaracter.Execute(texto, caractere);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/ConcatenarTextoCaracterTextoTests.cs
+++ b/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/ConcatenarTextoCaracterTextoTests.cs
@@ -1,0 +1,72 @@
+using Xunit;
+using Etiquetas.Bibliotecas.Comum.Caracteres;
+
+namespace Etiquetas.Bibliotecas.Comum.Tests.Caracteres
+{
+    public class ConcatenarTextoCaracterTextoTests
+    {
+        [Fact]
+        public void Execute_ComTextosEChar_RetornaConcatenacao()
+        {
+            // Arrange
+            var texto1 = "abc";
+            var caractere = '-';
+            var texto2 = "def";
+            var expected = "abc-def";
+
+            // Act
+            var result = ConcatenarTextoCaracterTexto.Execute(texto1, caractere, texto2);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComPrimeiroTextoNulo_ConcatenaCorretamente()
+        {
+            // Arrange
+            string texto1 = null;
+            var caractere = '-';
+            var texto2 = "def";
+            var expected = "-def";
+
+            // Act
+            var result = ConcatenarTextoCaracterTexto.Execute(texto1, caractere, texto2);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComSegundoTextoNulo_ConcatenaCorretamente()
+        {
+            // Arrange
+            var texto1 = "abc";
+            var caractere = '-';
+            string texto2 = null;
+            var expected = "abc-";
+
+            // Act
+            var result = ConcatenarTextoCaracterTexto.Execute(texto1, caractere, texto2);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComAmbosTextosNulos_RetornaCharComoString()
+        {
+            // Arrange
+            string texto1 = null;
+            var caractere = '-';
+            string texto2 = null;
+            var expected = "-";
+
+            // Act
+            var result = ConcatenarTextoCaracterTexto.Execute(texto1, caractere, texto2);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/ConcatenarVariosArraysStringEmStringTests.cs
+++ b/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/ConcatenarVariosArraysStringEmStringTests.cs
@@ -1,0 +1,72 @@
+using Xunit;
+using Etiquetas.Bibliotecas.Comum.Caracteres;
+
+namespace Etiquetas.Bibliotecas.Comum.Tests.Caracteres
+{
+    public class ConcatenarVariosArraysStringEmStringTests
+    {
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Execute_ComVariosArrays_RetornaConcatenacao(bool useLinq)
+        {
+            // Arrange
+            var array1 = new[] { "a", "b" };
+            var array2 = new[] { "c", "d" };
+            var expected = "abcd";
+
+            // Act
+            var result = useLinq ? ConcatenarVariosArraysStringEmString.ExecuteLinq(array1, array2) : ConcatenarVariosArraysStringEmString.ExecuteStringBuilder(array1, array2);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Execute_ComParametroNulo_RetornaStringVazia(bool useLinq)
+        {
+            // Arrange & Act
+            var result = useLinq ? ConcatenarVariosArraysStringEmString.ExecuteLinq(null) : ConcatenarVariosArraysStringEmString.ExecuteStringBuilder(null);
+
+            // Assert
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Execute_ComArrayInternoNulo_IgnoraArrayNulo(bool useLinq)
+        {
+            // Arrange
+            var array1 = new[] { "a", "b" };
+            string[] array2 = null;
+            var array3 = new[] { "c", "d" };
+            var expected = "abcd";
+
+            // Act
+            var result = useLinq ? ConcatenarVariosArraysStringEmString.ExecuteLinq(array1, array2, array3) : ConcatenarVariosArraysStringEmString.ExecuteStringBuilder(array1, array2, array3);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Execute_ComElementosNulosEVazios_PreservaElementos(bool useLinq)
+        {
+            // Arrange
+            var array1 = new[] { "a", null };
+            var array2 = new[] { "", "d" };
+            var expected = "ad"; // Concat trata null como ""
+
+            // Act
+            var result = useLinq ? ConcatenarVariosArraysStringEmString.ExecuteLinq(array1, array2) : ConcatenarVariosArraysStringEmString.ExecuteStringBuilder(array1, array2);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+    }
+}


### PR DESCRIPTION
Este commit continua o trabalho de adicionar cobertura de testes para a biblioteca `Etiquetas.Bibliotecas.Comum`, focando no diretório `Caracteres`.

- Adiciona testes de unidade para as classes `ConcatenarTextoCaracter`, `ConcatenarTextoCaracterSeUltimoCaracterDiferente`, `ConcatenarTextoCaracterTexto` e `ConcatenarVariosArraysStringEmString`.
- Corrige bugs e refatora as classes `ConcatenarTextoCaracterSeUltimoCaracterDiferente` e `ConcatenarVariosArraysStringEmString` para maior clareza e robustez.