### PR TITLE
Adiciona mais testes de unidade para a biblioteca Comum (lote 7)

### DIFF
--- a/Bibliotecas/EtiquetasBibliotecas.Comum/Caracteres/ControlCharConvert.cs
+++ b/Bibliotecas/EtiquetasBibliotecas.Comum/Caracteres/ControlCharConvert.cs
@@ -8,6 +8,15 @@ namespace Etiquetas.Bibliotecas.Comum.Caracteres
     {
         public static string Execute(string data, Dictionary<string, char> chrList)
         {
+            if (data == null)
+            {
+                return null;
+            }
+            if (chrList == null)
+            {
+                return data;
+            }
+
             // Inverte o dicionário para acessar pela chave de caractere
             var codeList = chrList.ToDictionary(x => x.Value, x => x.Key);
 

--- a/Bibliotecas/EtiquetasBibliotecas.Comum/Caracteres/ControlCharReplace.cs
+++ b/Bibliotecas/EtiquetasBibliotecas.Comum/Caracteres/ControlCharReplace.cs
@@ -7,28 +7,41 @@ namespace Etiquetas.Bibliotecas.Comum.Caracteres
     {
         public static string Execute(string data, Dictionary<string, char> chrList)
         {
-            var result = new StringBuilder(data);
+            if (string.IsNullOrEmpty(data) || chrList == null || chrList.Count == 0)
+                return data;
+
+            StringBuilder result = new StringBuilder();
             int startIndex = 0;
 
             while (startIndex < data.Length)
             {
-                int openBracketIndex = IndexOf.PosicaoKMP(result, "[", startIndex);
-                int closeBracketIndex = (openBracketIndex != -1) ? IndexOf.PosicaoKMP(result, "]", openBracketIndex + 1) : -1;
-                var procura = new StringBuilder();
-
-                if (openBracketIndex == -1 || closeBracketIndex == -1)
+                int openBracketIndex = data.IndexOf('[', startIndex);
+                if (openBracketIndex == -1)
                 {
+                    result.Append(data.Substring(startIndex));
                     break;
                 }
 
-                for (int i = openBracketIndex; i < (closeBracketIndex + 1); i++)
+                int closeBracketIndex = data.IndexOf(']', openBracketIndex + 1);
+                if (closeBracketIndex == -1)
                 {
-                    procura.Append(result[i]);
+                    result.Append(data.Substring(startIndex));
+                    break;
                 }
 
-                result.Replace(procura.ToString(), chrList[procura.ToString()].ToString());
+                result.Append(data.Substring(startIndex, openBracketIndex - startIndex));
 
-                // Atualize o índice de início para após o colchete de fechamento
+                string key = data.Substring(openBracketIndex, closeBracketIndex - openBracketIndex + 1);
+
+                if (chrList.TryGetValue(key, out char value))
+                {
+                    result.Append(value);
+                }
+                else
+                {
+                    result.Append(key);
+                }
+
                 startIndex = closeBracketIndex + 1;
             }
 

--- a/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/ControlCharConvertTests.cs
+++ b/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/ControlCharConvertTests.cs
@@ -1,0 +1,98 @@
+using Xunit;
+using Etiquetas.Bibliotecas.Comum.Caracteres;
+using System.Collections.Generic;
+
+namespace Etiquetas.Bibliotecas.Comum.Tests.Caracteres
+{
+    public class ControlCharConvertTests
+    {
+        [Fact]
+        public void Execute_ComCaracteresDeControle_ConverteCorretamente()
+        {
+            // Arrange
+            var chrList = new Dictionary<string, char> { { "<SOH>", (char)1 }, { "<STX>", (char)2 } };
+            var data = $"a{(char)1}b{(char)2}c";
+            var expected = "a<SOH>b<STX>c";
+
+            // Act
+            var result = ControlCharConvert.Execute(data, chrList);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_SemCaracteresDeControle_NaoAlteraString()
+        {
+            // Arrange
+            var chrList = new Dictionary<string, char> { { "<SOH>", (char)1 } };
+            var data = "abc";
+            var expected = "abc";
+
+            // Act
+            var result = ControlCharConvert.Execute(data, chrList);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComDadosNulos_RetornaNulo()
+        {
+            // Arrange
+            var chrList = new Dictionary<string, char> { { "<SOH>", (char)1 } };
+            string data = null;
+
+            // Act
+            var result = ControlCharConvert.Execute(data, chrList);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Execute_ComListaNula_RetornaDadosOriginais()
+        {
+            // Arrange
+            Dictionary<string, char> chrList = null;
+            var data = "abc";
+            var expected = "abc";
+
+            // Act
+            var result = ControlCharConvert.Execute(data, chrList);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComDadosVazios_RetornaStringVazia()
+        {
+            // Arrange
+            var chrList = new Dictionary<string, char> { { "<SOH>", (char)1 } };
+            var data = "";
+            var expected = "";
+
+            // Act
+            var result = ControlCharConvert.Execute(data, chrList);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComListaVazia_NaoAlteraString()
+        {
+            // Arrange
+            var chrList = new Dictionary<string, char>();
+            var data = "a\u0001b";
+            var expected = "a\u0001b";
+
+            // Act
+            var result = ControlCharConvert.Execute(data, chrList);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/ControlCharListTests.cs
+++ b/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/ControlCharListTests.cs
@@ -1,0 +1,70 @@
+using Xunit;
+using Etiquetas.Bibliotecas.Comum.Caracteres;
+using System.Linq;
+
+namespace Etiquetas.Bibliotecas.Comum.Tests.Caracteres
+{
+    public class ControlCharListTests
+    {
+        [Fact]
+        public void Execute_RetornaDicionarioNaoVazio()
+        {
+            // Arrange & Act
+            var result = ControlCharList.Execute();
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.NotEmpty(result);
+        }
+
+        [Fact]
+        public void Execute_ContemMapeamentoConhecido()
+        {
+            // Arrange
+            var expectedChar = '\u0001';
+            var expectedKey = "[SOH]";
+
+            // Act
+            var result = ControlCharList.Execute();
+
+            // Assert
+            Assert.True(result.ContainsKey(expectedKey));
+            Assert.Equal(expectedChar, result[expectedKey]);
+        }
+
+        [Fact]
+        public void ObtemArrayControlChar_RetornaArrayNaoVazio()
+        {
+            // Arrange & Act
+            var result = ControlCharList.ObtemArrayControlChar();
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.NotEmpty(result);
+        }
+
+        [Fact]
+        public void ObtemArrayControlChar_TamanhoCorrespondeAoDicionario()
+        {
+            // Arrange
+            var dictionary = ControlCharList.Execute();
+            var array = ControlCharList.ObtemArrayControlChar();
+
+            // Act & Assert
+            Assert.Equal(dictionary.Count, array.Length);
+        }
+
+        [Fact]
+        public void ObtemArrayControlChar_ContemCaractereDeControleConhecido()
+        {
+            // Arrange
+            var expectedChar = '\u001B'; // ESC
+
+            // Act
+            var result = ControlCharList.ObtemArrayControlChar();
+
+            // Assert
+            Assert.Contains(expectedChar, result);
+        }
+    }
+}

--- a/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/ControlCharReplaceTests.cs
+++ b/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/ControlCharReplaceTests.cs
@@ -1,0 +1,83 @@
+using Xunit;
+using Etiquetas.Bibliotecas.Comum.Caracteres;
+using System.Collections.Generic;
+
+namespace Etiquetas.Bibliotecas.Comum.Tests.Caracteres
+{
+    public class ControlCharReplaceTests
+    {
+        [Fact]
+        public void Execute_ComRepresentacoesDeControle_SubstituiCorretamente()
+        {
+            // Arrange
+            var chrList = new Dictionary<string, char> { { "[SOH]", (char)1 }, { "[STX]", (char)2 } };
+            var data = "a[SOH]b[STX]c";
+            var expected = $"a{(char)1}b{(char)2}c";
+
+            // Act
+            var result = ControlCharReplace.Execute(data, chrList);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_SemRepresentacoesDeControle_NaoAlteraString()
+        {
+            // Arrange
+            var chrList = new Dictionary<string, char> { { "[SOH]", (char)1 } };
+            var data = "abc";
+            var expected = "abc";
+
+            // Act
+            var result = ControlCharReplace.Execute(data, chrList);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComRepresentacaoNaoReconhecida_MantemOriginal()
+        {
+            // Arrange
+            var chrList = new Dictionary<string, char> { { "[SOH]", (char)1 } };
+            var data = "a[FOO]b";
+            var expected = "a[FOO]b";
+
+            // Act
+            var result = ControlCharReplace.Execute(data, chrList);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComDadosNulos_RetornaNulo()
+        {
+            // Arrange
+            var chrList = new Dictionary<string, char> { { "[SOH]", (char)1 } };
+            string data = null;
+
+            // Act
+            var result = ControlCharReplace.Execute(data, chrList);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Execute_ComListaNula_RetornaDadosOriginais()
+        {
+            // Arrange
+            Dictionary<string, char> chrList = null;
+            var data = "a[SOH]b";
+            var expected = "a[SOH]b";
+
+            // Act
+            var result = ControlCharReplace.Execute(data, chrList);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+    }
+}


### PR DESCRIPTION
Este commit continua o trabalho de adicionar cobertura de testes para a biblioteca `Etiquetas.Bibliotecas.Comum`, focando no diretório `Caracteres`.

- Adiciona testes de unidade para as classes `ControlCharConvert`, `ControlCharList` e `ControlCharReplace`.
- Corrige bugs e refatora as classes `ControlCharConvert` e `ControlCharReplace` para maior clareza e robustez.