### PR TITLE
Adiciona mais testes de unidade para a biblioteca Comum (lote 9)

### DIFF
--- a/Bibliotecas/EtiquetasBibliotecas.Comum/Caracteres/DecimalParaStringSemFormatacaoDaCultura.cs
+++ b/Bibliotecas/EtiquetasBibliotecas.Comum/Caracteres/DecimalParaStringSemFormatacaoDaCultura.cs
@@ -4,7 +4,7 @@
     {
         public static string Execute(this decimal value)
         {
-            return value.ToString();
+            return value.ToString(System.Globalization.CultureInfo.InvariantCulture);
         }
     }
 }

--- a/Bibliotecas/EtiquetasBibliotecas.Comum/Caracteres/DefineEncoding.cs
+++ b/Bibliotecas/EtiquetasBibliotecas.Comum/Caracteres/DefineEncoding.cs
@@ -9,8 +9,18 @@ namespace Etiquetas.Bibliotecas.Comum.Caracteres
 {
     public static class DefineEncoding
     {
+        static DefineEncoding()
+        {
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        }
+
         public static Encoding Execute(string nomeEncoding)
         {
+            if (string.IsNullOrWhiteSpace(nomeEncoding))
+            {
+                return Encoding.UTF8;
+            }
+
             var conversaoEncoding = Maiusculas.Execute(nomeEncoding);
             switch (conversaoEncoding)
             {
@@ -18,7 +28,7 @@ namespace Etiquetas.Bibliotecas.Comum.Caracteres
                     return Encoding.ASCII;
                 case "UTF-8":
                 case "UTF8":
-                    return  Encoding.UTF8;
+                    return Encoding.UTF8;
                 case "UTF-16":
                 case "UTF16":
                 case "UNICODE":
@@ -29,7 +39,7 @@ namespace Etiquetas.Bibliotecas.Comum.Caracteres
                 case "WINDOWS1252":
                 case "WINDOWS-1252":
                 case "1252":
-                    return  Encoding.GetEncoding(1252);
+                    return Encoding.GetEncoding(1252);
                 case "DOS LATIN-1":
                 case "MSDOS LATIN-1":
                 case "850":
@@ -41,7 +51,7 @@ namespace Etiquetas.Bibliotecas.Comum.Caracteres
                 case "DOS-US":
                 case "DOS US":
                 case "437":
-                    return Encoding.GetEncoding(850);
+                    return Encoding.GetEncoding(437);
                 default:
                     return Encoding.UTF8;
             }

--- a/Bibliotecas/EtiquetasBibliotecas.Comum/Caracteres/EhArrayCharNuloVazioComEspacosBranco.cs
+++ b/Bibliotecas/EtiquetasBibliotecas.Comum/Caracteres/EhArrayCharNuloVazioComEspacosBranco.cs
@@ -16,11 +16,11 @@ namespace Etiquetas.Bibliotecas.Comum.Caracteres
         /// </returns>
         public static bool Execute(this Char[] arrayChar)
         {
-            var arrayCharNulo = (arrayChar == null);
-            var arrayCharNuloOuVazio = arrayCharNulo || arrayChar.Length == 0;
-            arrayCharNuloOuVazio = arrayCharNuloOuVazio || arrayChar.All(x => EhStringNuloVazioComEspacosBranco.Execute(x.ToString()));
-            //Bibliotecas.COLibString.COEhStringNuloOuVazioOuComEspacosBranco.Execute(x.ToString()))
-            return arrayCharNuloOuVazio;
+            if (arrayChar == null || arrayChar.Length == 0)
+            {
+                return true;
+            }
+            return arrayChar.All(c => char.IsWhiteSpace(c));
         }
 
     }

--- a/Bibliotecas/EtiquetasBibliotecas.Comum/Etiquetas.Bibliotecas.Comum.csproj
+++ b/Bibliotecas/EtiquetasBibliotecas.Comum/Etiquetas.Bibliotecas.Comum.csproj
@@ -14,4 +14,8 @@
     <Folder Include="Numericos\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/DecimalParaStringSemFormatacaoDaCulturaTests.cs
+++ b/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/DecimalParaStringSemFormatacaoDaCulturaTests.cs
@@ -1,0 +1,45 @@
+using Xunit;
+using Etiquetas.Bibliotecas.Comum.Caracteres;
+using System.Globalization;
+using System.Threading;
+
+namespace Etiquetas.Bibliotecas.Comum.Tests.Caracteres
+{
+    public class DecimalParaStringSemFormatacaoDaCulturaTests
+    {
+        [Fact]
+        public void Execute_ComValorDecimal_RetornaStringComPonto()
+        {
+            // Arrange
+            decimal value = 123.45m;
+            var expected = "123.45";
+
+            // Forçar uma cultura que usa vírgula para garantir que a conversão é invariante
+            var originalCulture = Thread.CurrentThread.CurrentCulture;
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("pt-BR");
+
+            // Act
+            var result = DecimalParaStringSemFormatacaoDaCultura.Execute(value);
+
+            // Assert
+            Assert.Equal(expected, result);
+
+            // Cleanup
+            Thread.CurrentThread.CurrentCulture = originalCulture;
+        }
+
+        [Fact]
+        public void Execute_ComZero_RetornaStringZero()
+        {
+            // Arrange
+            decimal value = 0m;
+            var expected = "0";
+
+            // Act
+            var result = DecimalParaStringSemFormatacaoDaCultura.Execute(value);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/DefineEncodingTests.cs
+++ b/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/DefineEncodingTests.cs
@@ -1,0 +1,68 @@
+using Xunit;
+using Etiquetas.Bibliotecas.Comum.Caracteres;
+using System.Text;
+
+namespace Etiquetas.Bibliotecas.Comum.Tests.Caracteres
+{
+    public class DefineEncodingTests
+    {
+        [Theory]
+        [InlineData("ASCII", "us-ascii")]
+        [InlineData("UTF-8", "utf-8")]
+        [InlineData("UTF8", "utf-8")]
+        [InlineData("UTF-16", "utf-16")]
+        [InlineData("UNICODE", "utf-16")]
+        [InlineData("ISO-8859-1", "iso-8859-1")]
+        [InlineData("latin-1", "iso-8859-1")]
+        [InlineData("1252", "windows-1252")]
+        [InlineData("850", "ibm850")]
+        [InlineData("437", "ibm437")]
+        public void Execute_ComNomesValidos_RetornaEncodingCorreto(string nome, string expectedWebName)
+        {
+            // Arrange & Act
+            var result = DefineEncoding.Execute(nome);
+
+            // Assert
+            Assert.Equal(expectedWebName, result.WebName);
+        }
+
+        [Fact]
+        public void Execute_ComNomeInvalido_RetornaUTF8()
+        {
+            // Arrange
+            var nome = "invalido";
+
+            // Act
+            var result = DefineEncoding.Execute(nome);
+
+            // Assert
+            Assert.Equal(Encoding.UTF8, result);
+        }
+
+        [Fact]
+        public void Execute_ComNomeNulo_RetornaUTF8()
+        {
+            // Arrange
+            string nome = null;
+
+            // Act
+            var result = DefineEncoding.Execute(nome);
+
+            // Assert
+            Assert.Equal(Encoding.UTF8, result);
+        }
+
+        [Fact]
+        public void Execute_ComNomeVazio_RetornaUTF8()
+        {
+            // Arrange
+            var nome = "";
+
+            // Act
+            var result = DefineEncoding.Execute(nome);
+
+            // Assert
+            Assert.Equal(Encoding.UTF8, result);
+        }
+    }
+}

--- a/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/EhArrayCharNuloVazioComEspacosBrancoDBNullTests.cs
+++ b/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/EhArrayCharNuloVazioComEspacosBrancoDBNullTests.cs
@@ -1,0 +1,60 @@
+using Xunit;
+using Etiquetas.Bibliotecas.Comum.Caracteres;
+
+namespace Etiquetas.Bibliotecas.Comum.Tests.Caracteres
+{
+    public class EhArrayCharNuloVazioComEspacosBrancoDBNullTests
+    {
+        [Fact]
+        public void Execute_ComArrayNulo_RetornaTrue()
+        {
+            // Arrange
+            char[] array = null;
+
+            // Act
+            var result = EhArrayCharNuloVazioComEspacosBrancoDBNull.Execute(array);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void Execute_ComArrayVazio_RetornaTrue()
+        {
+            // Arrange
+            var array = new char[] { };
+
+            // Act
+            var result = EhArrayCharNuloVazioComEspacosBrancoDBNull.Execute(array);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void Execute_ComArrayDeEspacos_RetornaTrue()
+        {
+            // Arrange
+            var array = new[] { ' ', '\t', '\n' };
+
+            // Act
+            var result = EhArrayCharNuloVazioComEspacosBrancoDBNull.Execute(array);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void Execute_ComArrayComLetras_RetornaFalse()
+        {
+            // Arrange
+            var array = new[] { 'a', 'b', 'c' };
+
+            // Act
+            var result = EhArrayCharNuloVazioComEspacosBrancoDBNull.Execute(array);
+
+            // Assert
+            Assert.False(result);
+        }
+    }
+}

--- a/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/EhArrayCharNuloVazioComEspacosBrancoTests.cs
+++ b/Testes/Etiquetas.Bibliotecas.Comum.Tests/Caracteres/EhArrayCharNuloVazioComEspacosBrancoTests.cs
@@ -1,0 +1,73 @@
+using Xunit;
+using Etiquetas.Bibliotecas.Comum.Caracteres;
+
+namespace Etiquetas.Bibliotecas.Comum.Tests.Caracteres
+{
+    public class EhArrayCharNuloVazioComEspacosBrancoTests
+    {
+        [Fact]
+        public void Execute_ComArrayNulo_RetornaTrue()
+        {
+            // Arrange
+            char[] array = null;
+
+            // Act
+            var result = EhArrayCharNuloVazioComEspacosBranco.Execute(array);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void Execute_ComArrayVazio_RetornaTrue()
+        {
+            // Arrange
+            var array = new char[] { };
+
+            // Act
+            var result = EhArrayCharNuloVazioComEspacosBranco.Execute(array);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void Execute_ComArrayDeEspacos_RetornaTrue()
+        {
+            // Arrange
+            var array = new[] { ' ', '\t', '\n' };
+
+            // Act
+            var result = EhArrayCharNuloVazioComEspacosBranco.Execute(array);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void Execute_ComArrayComLetras_RetornaFalse()
+        {
+            // Arrange
+            var array = new[] { 'a', 'b', 'c' };
+
+            // Act
+            var result = EhArrayCharNuloVazioComEspacosBranco.Execute(array);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void Execute_ComArrayMisto_RetornaFalse()
+        {
+            // Arrange
+            var array = new[] { ' ', 'a', ' ' };
+
+            // Act
+            var result = EhArrayCharNuloVazioComEspacosBranco.Execute(array);
+
+            // Assert
+            Assert.False(result);
+        }
+    }
+}


### PR DESCRIPTION
Este commit continua o trabalho de adicionar cobertura de testes para a biblioteca `Etiquetas.Bibliotecas.Comum`, focando no diretório `Caracteres`.

- Adiciona testes de unidade para as classes `DecimalParaStringSemFormatacaoDaCultura`, `DefineEncoding`, `EhArrayCharNuloVazioComEspacosBranco` e `EhArrayCharNuloVazioComEspacosBrancoDBNull`.
- Corrige bugs e refatora as implementações para maior robustez, clareza e correção, incluindo a adição de suporte para mais encodings e o uso de cultura invariante.