### PR TITLE
Adiciona testes para o diretório Numericos

### DIFF
--- a/Bibliotecas/EtiquetasBibliotecas.Comum/Numericos/OitoBytesEmInt64.cs
+++ b/Bibliotecas/EtiquetasBibliotecas.Comum/Numericos/OitoBytesEmInt64.cs
@@ -19,14 +19,13 @@ namespace Etiquetas.Bibliotecas.Comum.Numericos
         {
             if (bytes == null)
             {
-                throw new Exception($"Tipo null invalido em OitoBytesInt64.");
+                throw new ArgumentNullException(nameof(bytes));
             }
 
             if ((bytes.Length - startIndex) < 8)
             {
-                throw new Exception($"Int64 utiliza no minimo 8 bytes. OitoBytesInt64.");
+                throw new ArgumentException("O array deve conter pelo menos 8 bytes a partir do índice inicial.", nameof(bytes));
             }
-            //return Execute(bytes[0], bytes[1], bytes[2], bytes[3]);
             return BitConverter.ToInt64(bytes, startIndex);
         }
     }

--- a/Bibliotecas/EtiquetasBibliotecas.Comum/Numericos/QuatroBytesEmInt32.cs
+++ b/Bibliotecas/EtiquetasBibliotecas.Comum/Numericos/QuatroBytesEmInt32.cs
@@ -21,14 +21,13 @@ namespace Etiquetas.Bibliotecas.Comum.Numericos
         {
             if (bytes == null)
             {
-                throw new Exception($"Tipo null invalido em QuatroBytesInt32.");
+                throw new ArgumentNullException(nameof(bytes));
             }
 
             if ((bytes.Length - startIndex) < 4)
             {
-                throw new Exception($"Int32 utiliza no minimo 4 bytes. QuatroBytesInt32.");
+                throw new ArgumentException("O array deve conter pelo menos 4 bytes a partir do índice inicial.", nameof(bytes));
             }
-            //return Execute(bytes[0], bytes[1], bytes[2], bytes[3]);
             return BitConverter.ToInt32(bytes, startIndex);
         }
 

--- a/Bibliotecas/EtiquetasBibliotecas.Comum/Numericos/StringParaInt64.cs
+++ b/Bibliotecas/EtiquetasBibliotecas.Comum/Numericos/StringParaInt64.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Etiquetas.Bibliotecas.Comum.Numericos
 {
-    public static class StringParaInt64OuLong
+    public static class StringParaInt64
     {
         public static Int64 Execute(string value)
         {

--- a/Testes/Etiquetas.Bibliotecas.Comum.Tests/Numericos/ConverteInt64EmOitoBytesTests.cs
+++ b/Testes/Etiquetas.Bibliotecas.Comum.Tests/Numericos/ConverteInt64EmOitoBytesTests.cs
@@ -1,0 +1,65 @@
+using Xunit;
+using Etiquetas.Bibliotecas.Comum.Numericos;
+using System;
+
+namespace Etiquetas.Bibliotecas.Comum.Tests.Numericos
+{
+    public class ConverteInt64EmOitoBytesTests
+    {
+        [Fact]
+        public void Execute_ComValorPositivo_RetornaArrayDeBytesCorreto()
+        {
+            // Arrange
+            long valor = 1234567890;
+            var expected = BitConverter.GetBytes(valor);
+
+            // Act
+            var result = ConverteInt64EmOitoBytes.Execute(valor);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComValorNegativo_RetornaArrayDeBytesCorreto()
+        {
+            // Arrange
+            long valor = -1234567890;
+            var expected = BitConverter.GetBytes(valor);
+
+            // Act
+            var result = ConverteInt64EmOitoBytes.Execute(valor);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComZero_RetornaArrayDeBytesCorreto()
+        {
+            // Arrange
+            long valor = 0;
+            var expected = BitConverter.GetBytes(valor);
+
+            // Act
+            var result = ConverteInt64EmOitoBytes.Execute(valor);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComMaxValor_RetornaArrayDeBytesCorreto()
+        {
+            // Arrange
+            long valor = long.MaxValue;
+            var expected = BitConverter.GetBytes(valor);
+
+            // Act
+            var result = ConverteInt64EmOitoBytes.Execute(valor);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/Testes/Etiquetas.Bibliotecas.Comum.Tests/Numericos/OitoBytesEmInt64Tests.cs
+++ b/Testes/Etiquetas.Bibliotecas.Comum.Tests/Numericos/OitoBytesEmInt64Tests.cs
@@ -1,0 +1,57 @@
+using Xunit;
+using Etiquetas.Bibliotecas.Comum.Numericos;
+using System;
+
+namespace Etiquetas.Bibliotecas.Comum.Tests.Numericos
+{
+    public class OitoBytesEmInt64Tests
+    {
+        [Fact]
+        public void Execute_ComArrayDeBytes_RetornaInt64Correto()
+        {
+            // Arrange
+            long valorOriginal = 1234567890123456789;
+            var bytes = BitConverter.GetBytes(valorOriginal);
+
+            // Act
+            var result = OitoBytesEmInt64.Execute(bytes);
+
+            // Assert
+            Assert.Equal(valorOriginal, result);
+        }
+
+        [Fact]
+        public void Execute_ComBytesIndividuais_RetornaInt64Correto()
+        {
+            // Arrange
+            long valorOriginal = 1;
+            var bytes = BitConverter.GetBytes(valorOriginal);
+
+            // Act
+            var result = OitoBytesEmInt64.Execute(bytes[7], bytes[6], bytes[5], bytes[4], bytes[3], bytes[2], bytes[1], bytes[0]);
+
+            // Assert
+            Assert.Equal(valorOriginal, result);
+        }
+
+        [Fact]
+        public void Execute_ComArrayNulo_LancaArgumentNullException()
+        {
+            // Arrange
+            byte[] bytes = null;
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => OitoBytesEmInt64.Execute(bytes));
+        }
+
+        [Fact]
+        public void Execute_ComArrayCurto_LancaArgumentException()
+        {
+            // Arrange
+            var bytes = new byte[] { 1, 2, 3, 4 };
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => OitoBytesEmInt64.Execute(bytes));
+        }
+    }
+}

--- a/Testes/Etiquetas.Bibliotecas.Comum.Tests/Numericos/QuatroBytesEmInt32Tests.cs
+++ b/Testes/Etiquetas.Bibliotecas.Comum.Tests/Numericos/QuatroBytesEmInt32Tests.cs
@@ -1,0 +1,57 @@
+using Xunit;
+using Etiquetas.Bibliotecas.Comum.Numericos;
+using System;
+
+namespace Etiquetas.Bibliotecas.Comum.Tests.Numericos
+{
+    public class QuatroBytesEmInt32Tests
+    {
+        [Fact]
+        public void Execute_ComArrayDeBytes_RetornaInt32Correto()
+        {
+            // Arrange
+            int valorOriginal = 123456789;
+            var bytes = BitConverter.GetBytes(valorOriginal);
+
+            // Act
+            var result = QuatroBytesEmInt32.Execute(bytes);
+
+            // Assert
+            Assert.Equal(valorOriginal, result);
+        }
+
+        [Fact]
+        public void Execute_ComBytesIndividuais_RetornaInt32Correto()
+        {
+            // Arrange
+            int valorOriginal = 1;
+            var bytes = BitConverter.GetBytes(valorOriginal);
+
+            // Act
+            var result = QuatroBytesEmInt32.Execute(bytes[3], bytes[2], bytes[1], bytes[0]);
+
+            // Assert
+            Assert.Equal(valorOriginal, result);
+        }
+
+        [Fact]
+        public void Execute_ComArrayNulo_LancaArgumentNullException()
+        {
+            // Arrange
+            byte[] bytes = null;
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => QuatroBytesEmInt32.Execute(bytes));
+        }
+
+        [Fact]
+        public void Execute_ComArrayCurto_LancaArgumentException()
+        {
+            // Arrange
+            var bytes = new byte[] { 1, 2 };
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => QuatroBytesEmInt32.Execute(bytes));
+        }
+    }
+}

--- a/Testes/Etiquetas.Bibliotecas.Comum.Tests/Numericos/StringParaInt16NuloTests.cs
+++ b/Testes/Etiquetas.Bibliotecas.Comum.Tests/Numericos/StringParaInt16NuloTests.cs
@@ -1,0 +1,61 @@
+using Xunit;
+using Etiquetas.Bibliotecas.Comum.Numericos;
+
+namespace Etiquetas.Bibliotecas.Comum.Tests.Numericos
+{
+    public class StringParaInt16NuloTests
+    {
+        [Fact]
+        public void Execute_ComStringValida_RetornaInt16()
+        {
+            // Arrange
+            var valor = "123";
+            short? expected = 123;
+
+            // Act
+            var result = StringParaInt16Nulo.Execute(valor);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComStringInvalida_RetornaNulo()
+        {
+            // Arrange
+            var valor = "abc";
+
+            // Act
+            var result = StringParaInt16Nulo.Execute(valor);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Execute_ComStringNula_RetornaNulo()
+        {
+            // Arrange
+            string valor = null;
+
+            // Act
+            var result = StringParaInt16Nulo.Execute(valor);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Execute_ComValorForaDoRange_RetornaNulo()
+        {
+            // Arrange
+            var valor = "32768"; // Int16.MaxValue + 1
+
+            // Act
+            var result = StringParaInt16Nulo.Execute(valor);
+
+            // Assert
+            Assert.Null(result);
+        }
+    }
+}

--- a/Testes/Etiquetas.Bibliotecas.Comum.Tests/Numericos/StringParaInt64Tests.cs
+++ b/Testes/Etiquetas.Bibliotecas.Comum.Tests/Numericos/StringParaInt64Tests.cs
@@ -1,0 +1,61 @@
+using Xunit;
+using Etiquetas.Bibliotecas.Comum.Numericos;
+
+namespace Etiquetas.Bibliotecas.Comum.Tests.Numericos
+{
+    public class StringParaInt64Tests
+    {
+        [Fact]
+        public void Execute_ComStringValida_RetornaInt64()
+        {
+            // Arrange
+            var valor = "1234567890123";
+            long expected = 1234567890123;
+
+            // Act
+            var result = StringParaInt64.Execute(valor);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComStringInvalida_RetornaZero()
+        {
+            // Arrange
+            var valor = "abc";
+
+            // Act
+            var result = StringParaInt64.Execute(valor);
+
+            // Assert
+            Assert.Equal(0, result);
+        }
+
+        [Fact]
+        public void Execute_ComStringNula_RetornaZero()
+        {
+            // Arrange
+            string valor = null;
+
+            // Act
+            var result = StringParaInt64.Execute(valor);
+
+            // Assert
+            Assert.Equal(0, result);
+        }
+
+        [Fact]
+        public void Execute_ComValorForaDoRange_RetornaZero()
+        {
+            // Arrange
+            var valor = "9223372036854775808"; // long.MaxValue + 1
+
+            // Act
+            var result = StringParaInt64.Execute(valor);
+
+            // Assert
+            Assert.Equal(0, result);
+        }
+    }
+}

--- a/Testes/Etiquetas.Bibliotecas.Comum.Tests/Numericos/StringParaIntNuloTests.cs
+++ b/Testes/Etiquetas.Bibliotecas.Comum.Tests/Numericos/StringParaIntNuloTests.cs
@@ -1,0 +1,61 @@
+using Xunit;
+using Etiquetas.Bibliotecas.Comum.Numericos;
+
+namespace Etiquetas.Bibliotecas.Comum.Tests.Numericos
+{
+    public class StringParaIntNuloTests
+    {
+        [Fact]
+        public void Execute_ComStringValida_RetornaInt()
+        {
+            // Arrange
+            var valor = "123";
+            int? expected = 123;
+
+            // Act
+            var result = StringParaIntNulo.Execute(valor);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_ComStringInvalida_RetornaNulo()
+        {
+            // Arrange
+            var valor = "abc";
+
+            // Act
+            var result = StringParaIntNulo.Execute(valor);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Execute_ComStringNula_RetornaNulo()
+        {
+            // Arrange
+            string valor = null;
+
+            // Act
+            var result = StringParaIntNulo.Execute(valor);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Execute_ComValorForaDoRange_RetornaNulo()
+        {
+            // Arrange
+            var valor = "2147483648"; // int.MaxValue + 1
+
+            // Act
+            var result = StringParaIntNulo.Execute(valor);
+
+            // Assert
+            Assert.Null(result);
+        }
+    }
+}


### PR DESCRIPTION
Este commit adiciona cobertura de testes para as classes no diretório `Numericos` da biblioteca `Etiquetas.Bibliotecas.Comum`.

- Adiciona testes de unidade para as classes `ConverteInt64EmOitoBytes`, `OitoBytesEmInt64`, `QuatroBytesEmInt32`, `StringParaInt16Nulo`, `StringParaInt64` e `StringParaIntNulo`.
- Corrige bugs e refatora as implementações para maior robustez, clareza e para usar exceções padrão da indústria.